### PR TITLE
Demo for custom step symbol template.

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,6 +6,7 @@ import {LargeEmptySymbolsComponent} from './large-empty-symbols/large-empty-symb
 import {LargeFilledSymbolsComponent} from './large-filled-symbols/large-filled-symbols.component';
 import {BasicStepSymbolComponent} from './basic-step-symbol/basic-step-symbol.component';
 import {CustomStepSymbolComponent} from './custom-step-symbol/custom-step-symbol.component';
+import {CustomStepSymbolTemplateComponent} from './custom-step-symbol-template/custom-step-symbol-template.component';
 import {LocationBottomComponent} from './location-bottom/location-bottom.component';
 import {LocationRightComponent} from './location-right/location-right.component';
 import {LocationLeftComponent} from './location-left/location-left.component';
@@ -44,6 +45,7 @@ const appRoutes: Routes = [
   { path: 'layout/large-empty-symbols', component: LargeEmptySymbolsComponent },
   { path: 'navigation-symbol/basic', component: BasicStepSymbolComponent },
   { path: 'navigation-symbol/custom', component: CustomStepSymbolComponent },
+  { path: 'navigation-symbol/custom-template', component: CustomStepSymbolTemplateComponent },
   { path: 'navigation-location/top', component: LocationTopComponent },
   { path: 'navigation-location/left', component: LocationLeftComponent },
   { path: 'navigation-location/right', component: LocationRightComponent },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,7 @@ import {LargeFilledSymbolsModule} from './large-filled-symbols/large-filled-symb
 import {LargeEmptySymbolsModule} from './large-empty-symbols/large-empty-symbols.module';
 import {BasicStepSymbolModule} from './basic-step-symbol/basic-step-symbol.module';
 import {CustomStepSymbolModule} from './custom-step-symbol/custom-step-symbol.module';
+import {CustomStepSymbolTemplateModule} from './custom-step-symbol-template/custom-step-symbol-template.module';
 import {LocationTopModule} from './location-top/location-top.module';
 import {LocationBottomModule} from './location-bottom/location-bottom.module';
 import {LocationLeftModule} from './location-left/location-left.module';
@@ -50,6 +51,7 @@ import {CustomCssModule} from './custom-css/custom-css.module';
     LargeEmptySymbolsModule,
     BasicStepSymbolModule,
     CustomStepSymbolModule,
+    CustomStepSymbolTemplateModule,
     LocationTopModule,
     LocationBottomModule,
     LocationLeftModule,

--- a/src/app/custom-step-symbol-template/custom-step-symbol-template.component.css
+++ b/src/app/custom-step-symbol-template/custom-step-symbol-template.component.css
@@ -1,0 +1,4 @@
+.centered-content {
+  margin: auto;
+  text-align: center;
+}

--- a/src/app/custom-step-symbol-template/custom-step-symbol-template.component.html
+++ b/src/app/custom-step-symbol-template/custom-step-symbol-template.component.html
@@ -1,0 +1,41 @@
+<aw-wizard #wizard [navBarLayout]="'large-empty-symbols'">
+  <aw-wizard-step [stepTitle]="'Steptitle 1'">
+    <ng-template awWizardStepSymbol><i class="fa fa-search"></i></ng-template>
+    <div class="centered-content">
+      <div>
+        Content: Step 1
+      </div>
+
+      <div class="btn-group">
+        <button type="button" class="btn btn-secondary" awNextStep>Continue</button>
+      </div>
+    </div>
+  </aw-wizard-step>
+  <aw-wizard-step [stepTitle]="'Steptitle 2'">
+    <ng-template awWizardStepSymbol><i class="fa fa-upload"></i></ng-template>
+    <div class="centered-content">
+      <div>
+        Content: Step 2
+      </div>
+
+      <div class="btn-group">
+        <button type="button" class="btn btn-secondary" awPreviousStep>Back</button>
+        <button type="button" class="btn btn-secondary" awNextStep>Continue</button>
+      </div>
+    </div>
+  </aw-wizard-step>
+  <aw-wizard-step [stepTitle]="'Steptitle 3'">
+    <ng-template awWizardStepSymbol><i class="fa fa-file"></i></ng-template>
+    <div class="centered-content">
+      <div>
+        Content: Step 3
+      </div>
+
+      <div class="btn-group">
+        <button type="button" class="btn btn-secondary" awPreviousStep>Back</button>
+        <button type="button" class="btn btn-secondary" awResetWizard>Reset</button>
+      </div>
+    </div>
+  </aw-wizard-step>
+</aw-wizard>
+

--- a/src/app/custom-step-symbol-template/custom-step-symbol-template.component.spec.ts
+++ b/src/app/custom-step-symbol-template/custom-step-symbol-template.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CustomStepSymbolTemplateComponent } from './custom-step-symbol-template.component';
+
+describe('CustomStepSymbolComponent', () => {
+  let component: CustomStepSymbolTemplateComponent;
+  let fixture: ComponentFixture<CustomStepSymbolTemplateComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CustomStepSymbolTemplateComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CustomStepSymbolTemplateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/custom-step-symbol-template/custom-step-symbol-template.component.ts
+++ b/src/app/custom-step-symbol-template/custom-step-symbol-template.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-custom-step-symbol-template',
+  templateUrl: './custom-step-symbol-template.component.html',
+  styleUrls: ['./custom-step-symbol-template.component.css']
+})
+export class CustomStepSymbolTemplateComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/custom-step-symbol-template/custom-step-symbol-template.module.ts
+++ b/src/app/custom-step-symbol-template/custom-step-symbol-template.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CustomStepSymbolTemplateComponent } from './custom-step-symbol-template.component';
+import {ArchwizardModule} from 'angular-archwizard';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ArchwizardModule
+  ],
+  declarations: [CustomStepSymbolTemplateComponent],
+  exports: [CustomStepSymbolTemplateComponent]
+})
+export class CustomStepSymbolTemplateModule { }

--- a/src/app/demo/demo.component.html
+++ b/src/app/demo/demo.component.html
@@ -42,6 +42,9 @@
               <li routerLink="/navigation-symbol/custom" routerLinkActive="active">
                 <a>Custom font</a>
               </li>
+              <li routerLink="/navigation-symbol/custom-template" routerLinkActive="active">
+                <a>Custom template</a>
+              </li>
             </ul>
 
             <li data-toggle="collapse" data-target="#navBarLocation" class="collapsed">


### PR DESCRIPTION
![sidebar item](https://user-images.githubusercontent.com/52021/46206165-d20ede80-c32b-11e8-94d6-2644300f438d.png)

For this demo, I chose a different set of FontAwesome icons so that the wizard is different from the one on the 'Custom font' page.

![wizard](https://user-images.githubusercontent.com/52021/46206245-0b474e80-c32c-11e8-932a-2c872b3a83da.png)
