### PR TITLE
Fix a bug in the arbitrary step navigation example

### DIFF
--- a/src/app/arbitrary-step-navigation/arbitrary-step-navigation.component.html
+++ b/src/app/arbitrary-step-navigation/arbitrary-step-navigation.component.html
@@ -2,7 +2,7 @@
   <aw-wizard-step [stepTitle]="'Steptitle 1'">
     <div class="centered-content">
       <div>
-        Content: Step 1
+        Navigate to the next step using a fixed step index.
       </div>
 
       <div class="btn-group">
@@ -13,7 +13,8 @@
   <aw-wizard-step [stepTitle]="'Steptitle 2'" #secondStep>
     <div class="centered-content">
       <div>
-        Content: Step 2
+        Navigate to the previous step using a fixed step index.
+        Navigate to the next step using a step offset.
       </div>
 
       <div class="btn-group">
@@ -25,11 +26,11 @@
   <aw-wizard-step [stepTitle]="'Steptitle 3'">
     <div class="centered-content">
       <div>
-        Content: Step 3
+        Navigate to the previous step using a step reference.
       </div>
 
       <div class="btn-group">
-        <button type="button" class="btn btn-secondary" [awGoToStep]="{ stepIndex: secondStep }">Back</button>
+        <button type="button" class="btn btn-secondary" [awGoToStep]="secondStep">Back</button>
         <button type="button" class="btn btn-secondary" awResetWizard>Reset</button>
       </div>
     </div>


### PR DESCRIPTION
This PR fixes a bug in the arbitrary step navigation example, where a step reference was given instead of an index. In addition this PR replaces the step content with something more meaningful.