### PR TITLE
Add a demo page for initially completed wizard steps (awCompletedStep directive)

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -33,6 +33,7 @@ import {ReversedNavigationBarComponent} from './reversed-navigation-bar/reversed
 import {WizardStepNgForComponent} from './wizard-step-ngfor/wizard-step-ngfor.component';
 import {CustomGlobalCssComponent} from './custom-global-css/custom-global-css.component';
 import {CustomStepCssComponent} from './custom-step-css/custom-step-css.component';
+import {InitiallyCompletedWizardStepsComponent} from './initially-completed-wizard-steps/initially-completed-wizard-steps.component';
 
 /**
  * Created by marc on 09.07.17.
@@ -66,6 +67,7 @@ const appRoutes: Routes = [
   { path: 'custom-step-titles', component: CustomStepTitlesComponent },
   { path: 'optional-steps', component: OptionalStepsComponent },
   { path: 'default-step-index', component: DefaultWizardStepComponent },
+  { path: 'initially-completed-wizard-steps', component: InitiallyCompletedWizardStepsComponent },
   { path: 'arbitrary-step-navigation', component: ArbitraryStepNavigationComponent },
   { path: 'wizard-step-directives', component: WizardStepDirectivesComponent },
   { path: 'reset-wizard', component: ResetWizardComponent },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,6 +36,7 @@ import {WizardStepNgForModule} from './wizard-step-ngfor/wizard-step-ngfor.modul
 import {CustomGlobalCssModule} from './custom-global-css/custom-global-css.module';
 import {CustomStepCssModule} from './custom-step-css/custom-step-css.module';
 import {CustomNavigationModeModule} from './custom-navigation-mode/custom-navigation-mode.module';
+import {InitiallyCompletedWizardStepsModule} from './initially-completed-wizard-steps/initially-completed-wizard-steps.module';
 
 @NgModule({
   declarations: [
@@ -73,6 +74,7 @@ import {CustomNavigationModeModule} from './custom-navigation-mode/custom-naviga
     FreeNavigationModeModule,
     CanEnterEventModule,
     DefaultWizardStepModule,
+    InitiallyCompletedWizardStepsModule,
     ReversedNavigationBarModule,
     WizardStepNgForModule,
     CustomGlobalCssModule,

--- a/src/app/demo/demo.component.html
+++ b/src/app/demo/demo.component.html
@@ -134,7 +134,11 @@
             </li>
 
             <li routerLink="/default-step-index" routerLinkActive="active">
-              <a>Default wizard step / Initial wizard step</a>
+              <a>Default wizard step</a>
+            </li>
+
+            <li routerLink="/initially-completed-wizard-steps" routerLinkActive="active">
+              <a>Initially completed wizard steps</a>
             </li>
 
             <li routerLink="/arbitrary-step-navigation" routerLinkActive="active">

--- a/src/app/initially-completed-wizard-steps/initially-completed-wizard-steps.component.css
+++ b/src/app/initially-completed-wizard-steps/initially-completed-wizard-steps.component.css
@@ -1,0 +1,4 @@
+.centered-content {
+  margin: auto;
+  text-align: center;
+}

--- a/src/app/initially-completed-wizard-steps/initially-completed-wizard-steps.component.html
+++ b/src/app/initially-completed-wizard-steps/initially-completed-wizard-steps.component.html
@@ -1,0 +1,53 @@
+<p style="margin: 1em 0;">
+  You can mark one or more steps initially completed, if they are automatically filled with some derived/predefined information, using the <code>awCompletedStep</code> directive.
+  In many cases, the default step index needs to be adjusted accordingly as well.  In the example below, step 1 is initially completed, and step 2 is selected by default.
+</p>
+
+<aw-wizard #wizard>
+  <aw-wizard-step [stepTitle]="'Steptitle 1'" awCompletedStep>
+    <div class="centered-content">
+      <div>
+        Content: Step 1
+      </div>
+
+      <div class="btn-group">
+        <button type="button" class="btn btn-secondary" awNextStep>Continue</button>
+      </div>
+    </div>
+  </aw-wizard-step>
+  <aw-wizard-step [stepTitle]="'Steptitle 2'" awSelectedStep>
+    <div class="centered-content">
+      <div>
+        Content: Step 2
+      </div>
+
+      <div class="btn-group">
+        <button type="button" class="btn btn-secondary" awPreviousStep>Back</button>
+        <button type="button" class="btn btn-secondary" awNextStep>Continue</button>
+      </div>
+    </div>
+  </aw-wizard-step>
+  <aw-wizard-step [stepTitle]="'Steptitle 3'">
+    <div class="centered-content">
+      <div>
+        Content: Step 3
+      </div>
+
+      <div class="btn-group">
+        <button type="button" class="btn btn-secondary" awPreviousStep>Back</button>
+        <button type="button" class="btn btn-secondary" awNextStep>Continue</button>
+      </div>
+    </div>
+  </aw-wizard-step>
+  <aw-wizard-completion-step [stepTitle]="'Completion steptitle'">
+    <div class="centered-content">
+      <div>
+        Completion step content
+      </div>
+
+      <div class="btn-group">
+        <button type="button" class="btn btn-secondary" awResetWizard>Reset</button>
+      </div>
+    </div>
+  </aw-wizard-completion-step>
+</aw-wizard>

--- a/src/app/initially-completed-wizard-steps/initially-completed-wizard-steps.component.ts
+++ b/src/app/initially-completed-wizard-steps/initially-completed-wizard-steps.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-initially-completed-wizard-steps',
+  templateUrl: './initially-completed-wizard-steps.component.html',
+  styleUrls: ['./initially-completed-wizard-steps.component.css']
+})
+export class InitiallyCompletedWizardStepsComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/initially-completed-wizard-steps/initially-completed-wizard-steps.module.ts
+++ b/src/app/initially-completed-wizard-steps/initially-completed-wizard-steps.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { InitiallyCompletedWizardStepsComponent } from './initially-completed-wizard-steps.component';
+import {ArchwizardModule} from 'angular-archwizard';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ArchwizardModule
+  ],
+  declarations: [InitiallyCompletedWizardStepsComponent],
+  exports: [InitiallyCompletedWizardStepsComponent]
+})
+export class InitiallyCompletedWizardStepsModule { }

--- a/src/app/initially-completed-wizard-steps/initially-completed-wizard-steps.spec.ts
+++ b/src/app/initially-completed-wizard-steps/initially-completed-wizard-steps.spec.ts
@@ -1,0 +1,26 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InitiallyCompletedWizardStepsComponent } from './initially-completed-wizard-steps.component';
+import { InitiallyCompletedWizardStepsModule } from './initially-completed-wizard-steps.module';
+
+describe('InitiallyCompletedWizardStepsComponent', () => {
+  let component: InitiallyCompletedWizardStepsComponent;
+  let fixture: ComponentFixture<InitiallyCompletedWizardStepsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [ InitiallyCompletedWizardStepsModule ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(InitiallyCompletedWizardStepsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Demo for https://github.com/madoar/angular-archwizard/pull/218

Based on top of the `configurable-nav-mode` branch, https://github.com/madoar/angular-archwizard-demo/pull/40

![image](https://user-images.githubusercontent.com/52021/60057966-2c887000-96ef-11e9-952e-72d32c7a2dae.png)

<a href="https://gitpod.io/#https://github.com/madoar/angular-archwizard-demo/pull/45"><img src="https://gitpod.io/api/apps/github/pbs/github.com/earshinov/angular-archwizard-demo.git/4c125ce307e13671ff4979a99e905119d5a7611e.svg" /></a>

