### PR TITLE
Add an example for madoar/angular-archwizard#252

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -36,6 +36,7 @@ import { WizardStepNgForComponent } from './wizard-step-ngfor/wizard-step-ngfor.
 import { CustomGlobalCssComponent } from './custom-global-css/custom-global-css.component';
 import { CustomGlobalScssComponent } from './custom-global-scss/custom-global-scss.component';
 import { CustomStepCssComponent } from './custom-step-css/custom-step-css.component';
+import { CustomLineCssComponent } from './custom-line-css/custom-line-css.component';
 import { InitiallyCompletedWizardStepsComponent } from './initially-completed-wizard-steps/initially-completed-wizard-steps.component';
 import { SingleStepHorizontalComponent } from './single-step-horizontal/single-step-horizontal.component';
 import { SingleStepVerticalComponent } from './single-step-vertical/single-step-vertical.component';
@@ -73,6 +74,7 @@ const appRoutes: Routes = [
   { path: 'custom-css/global', component: CustomGlobalCssComponent },
   { path: 'custom-css/global-scss', component: CustomGlobalScssComponent },
   { path: 'custom-css/step', component: CustomStepCssComponent },
+  { path: 'custom-css/line', component: CustomLineCssComponent },
   { path: 'single-step/horizontal', component: SingleStepHorizontalComponent },
   { path: 'single-step/vertical', component: SingleStepVerticalComponent },
   { path: 'optional-steps', component: OptionalStepsComponent },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -38,6 +38,7 @@ import { WizardStepNgForModule } from './wizard-step-ngfor/wizard-step-ngfor.mod
 import { CustomGlobalCssModule } from './custom-global-css/custom-global-css.module';
 import { CustomGlobalScssModule } from './custom-global-scss/custom-global-scss.module';
 import { CustomStepCssModule } from './custom-step-css/custom-step-css.module';
+import { CustomLineCssModule } from './custom-line-css/custom-line-css.module';
 import { CustomNavigationModeModule } from './custom-navigation-mode/custom-navigation-mode.module';
 import { InitiallyCompletedWizardStepsModule } from './initially-completed-wizard-steps/initially-completed-wizard-steps.module';
 import { SingleStepHorizontalModule } from './single-step-horizontal/single-step-horizontal.module';
@@ -87,6 +88,7 @@ import { SingleStepVerticalModule } from './single-step-vertical/single-step-ver
     CustomGlobalCssModule,
     CustomGlobalScssModule,
     CustomStepCssModule,
+    CustomLineCssModule,
     CustomNavigationModeModule,
     SingleStepHorizontalModule,
     SingleStepVerticalModule,

--- a/src/app/custom-line-css/custom-line-css.component.html
+++ b/src/app/custom-line-css/custom-line-css.component.html
@@ -1,0 +1,37 @@
+<aw-wizard class="custom-line-css">
+  <aw-wizard-step [stepTitle]="'Steptitle 1'">
+    <div class="centered-content">
+      <div>
+        Content: Step 1
+      </div>
+
+      <div class="btn-group">
+        <button type="button" class="btn btn-secondary" awNextStep>Continue</button>
+      </div>
+    </div>
+  </aw-wizard-step>
+  <aw-wizard-step [stepTitle]="'Steptitle 2'">
+    <div class="centered-content">
+      <div>
+        Content: Step 2
+      </div>
+
+      <div class="btn-group">
+        <button type="button" class="btn btn-secondary" awPreviousStep>Back</button>
+        <button type="button" class="btn btn-secondary" awNextStep>Continue</button>
+      </div>
+    </div>
+  </aw-wizard-step>
+  <aw-wizard-step [stepTitle]="'Steptitle 3'">
+    <div class="centered-content">
+      <div>
+        Content: Step 3
+      </div>
+
+      <div class="btn-group">
+        <button type="button" class="btn btn-secondary" awPreviousStep>Back</button>
+        <button type="button" class="btn btn-secondary" awResetWizard>Reset</button>
+      </div>
+    </div>
+  </aw-wizard-step>
+</aw-wizard>

--- a/src/app/custom-line-css/custom-line-css.component.scss
+++ b/src/app/custom-line-css/custom-line-css.component.scss
@@ -1,0 +1,10 @@
+.centered-content {
+  margin: auto;
+  text-align: center;
+}
+
+aw-wizard.custom-line-css {
+  aw-wizard-navigation-bar.horizontal ul.steps-indicator li.done:not(:last-child):after {
+    background-color: green !important;
+  }
+}

--- a/src/app/custom-line-css/custom-line-css.component.spec.ts
+++ b/src/app/custom-line-css/custom-line-css.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { CustomLineCssComponent } from './custom-line-css.component';
+import { CustomLineCssModule } from './custom-line-css.module';
+
+describe('CustomLineCssComponent', () => {
+  let component: CustomLineCssComponent;
+  let fixture: ComponentFixture<CustomLineCssComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [CustomLineCssModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CustomLineCssComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/custom-line-css/custom-line-css.component.ts
+++ b/src/app/custom-line-css/custom-line-css.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'app-custom-line-css',
+  templateUrl: './custom-line-css.component.html',
+  styleUrls: ['./custom-line-css.component.scss'],
+  encapsulation: ViewEncapsulation.None
+})
+export class CustomLineCssComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/custom-line-css/custom-line-css.module.ts
+++ b/src/app/custom-line-css/custom-line-css.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CustomLineCssComponent } from './custom-line-css.component';
+import { ArchwizardModule } from 'angular-archwizard';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ArchwizardModule
+  ],
+  declarations: [CustomLineCssComponent],
+  exports: [CustomLineCssComponent]
+})
+export class CustomLineCssModule { }

--- a/src/app/demo/demo.component.html
+++ b/src/app/demo/demo.component.html
@@ -154,6 +154,9 @@
           <li routerLink="/custom-css/step" routerLinkActive="active">
             <a>Custom step CSS</a>
           </li>
+          <li routerLink="/custom-css/line" routerLinkActive="active">
+            <a>Custom line CSS</a>
+          </li>
         </ul>
 
         <li data-toggle="collapse" data-target="#singleStep" class="sub-menu-label collapsed"


### PR DESCRIPTION
This PR adds an example for changing the lines between the step indicators in the navigation bar

<a href="https://gitpod.io/#https://github.com/madoar/angular-archwizard-demo/pull/61"><img src="https://gitpod.io/api/apps/github/pbs/github.com/madoar/angular-archwizard-demo.git/eaf15140c603dd68f5b9964eb8fee9bc4311923c.svg" /></a>

