### PR TITLE
Remove detectChanges call

### DIFF
--- a/src/app/wizard-step-ngfor/wizard-step-ngfor.component.ts
+++ b/src/app/wizard-step-ngfor/wizard-step-ngfor.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, ChangeDetectorRef, AfterViewInit} from '@angular/core';
+import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
 
 interface WizardStepDescriptor {
   header: string;
@@ -10,10 +10,10 @@ interface WizardStepDescriptor {
   templateUrl: './wizard-step-ngfor.component.html',
   styleUrls: ['./wizard-step-ngfor.component.css']
 })
-export class WizardStepNgForComponent implements OnInit, AfterViewInit {
-  wizardSteps: WizardStepDescriptor[];
+export class WizardStepNgForComponent implements OnInit {
+  public wizardSteps: WizardStepDescriptor[];
 
-  constructor(private _changeDetectionRef: ChangeDetectorRef) {
+  constructor() {
 
     this.wizardSteps = [
       {
@@ -33,11 +33,6 @@ export class WizardStepNgForComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit() {
-  }
-
-  ngAfterViewInit(): void {
-    // Force another change detection in order to fix the ngFor error
-    this._changeDetectionRef.detectChanges();
   }
 
 }


### PR DESCRIPTION
This PR removes the `ChangeDetectorRef#detectChanges` call from the `*ngFor` example.

<a href="https://gitpod.io/#https://github.com/madoar/angular-archwizard-demo/pull/70"><img src="https://gitpod.io/api/apps/github/pbs/github.com/madoar/angular-archwizard-demo.git/49a91092a6bd261520d8640b0ade97b6f8d3c327.svg" /></a>

