### PR TITLE
Fix custom line CSS example during editing state

### DIFF
--- a/src/app/custom-line-css/custom-line-css.component.scss
+++ b/src/app/custom-line-css/custom-line-css.component.scss
@@ -4,7 +4,7 @@
 }
 
 aw-wizard.custom-line-css {
-  aw-wizard-navigation-bar.horizontal ul.steps-indicator li.done:not(:last-child):after {
+  aw-wizard-navigation-bar.horizontal ul.steps-indicator li.done:not(.editing):not(:last-child):after {
     background-color: green !important;
   }
 }


### PR DESCRIPTION
This PR fixes an issue with the line css example where a green outgoing line is shown for the editing state.

<a href="https://gitpod.io/#https://github.com/madoar/angular-archwizard-demo/pull/71"><img src="https://gitpod.io/api/apps/github/pbs/github.com/madoar/angular-archwizard-demo.git/5621805af30810bd39a0febdfc8e902244dc0670.svg" /></a>

