### PR TITLE
enhancement: add an example for nested wizards

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -40,6 +40,7 @@ import { CustomLineCssComponent } from './custom-line-css/custom-line-css.compon
 import { InitiallyCompletedWizardStepsComponent } from './initially-completed-wizard-steps/initially-completed-wizard-steps.component';
 import { SingleStepHorizontalComponent } from './single-step-horizontal/single-step-horizontal.component';
 import { SingleStepVerticalComponent } from './single-step-vertical/single-step-vertical.component';
+import { NestedWizardsComponent } from './nested-wizards/nested-wizards.component';
 
 /**
  * Created by marc on 09.07.17.
@@ -85,6 +86,7 @@ const appRoutes: Routes = [
   { path: 'reset-wizard', component: ResetWizardComponent },
   { path: 'reversed-navigation-bar', component: ReversedNavigationBarComponent },
   { path: 'wizard-step-ngfor', component: WizardStepNgForComponent },
+  { path: 'nested-wizards', component: NestedWizardsComponent },
   { path: '', redirectTo: '/basic', pathMatch: 'full' }
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -43,6 +43,7 @@ import { CustomNavigationModeModule } from './custom-navigation-mode/custom-navi
 import { InitiallyCompletedWizardStepsModule } from './initially-completed-wizard-steps/initially-completed-wizard-steps.module';
 import { SingleStepHorizontalModule } from './single-step-horizontal/single-step-horizontal.module';
 import { SingleStepVerticalModule } from './single-step-vertical/single-step-vertical.module';
+import { NestedWizardsModule } from './nested-wizards/nested-wizards.module';
 
 @NgModule({
   declarations: [
@@ -92,6 +93,7 @@ import { SingleStepVerticalModule } from './single-step-vertical/single-step-ver
     CustomNavigationModeModule,
     SingleStepHorizontalModule,
     SingleStepVerticalModule,
+    NestedWizardsModule
   ],
   providers: [],
   bootstrap: [DemoComponent]

--- a/src/app/demo/demo.component.html
+++ b/src/app/demo/demo.component.html
@@ -223,6 +223,10 @@
         <li routerLink="/wizard-step-ngfor" routerLinkActive="active">
           <a>Wizard step with *ngFor</a>
         </li>
+
+        <li routerLink="/nested-wizards" routerLinkActive="active">
+          <a>Nested wizards</a>
+        </li>
       </ul>
     </div>
   </div>

--- a/src/app/nested-wizards/inner-wizard.component.css
+++ b/src/app/nested-wizards/inner-wizard.component.css
@@ -1,0 +1,4 @@
+.centered-content {
+  margin: auto;
+  text-align: center;
+}

--- a/src/app/nested-wizards/inner-wizard.component.html
+++ b/src/app/nested-wizards/inner-wizard.component.html
@@ -1,0 +1,26 @@
+<aw-wizard #innerWizard [navBarLocation]="'left'">
+  <aw-wizard-step [stepTitle]="'Steptitle 1a'">
+    <div class="centered-content">
+      <div>
+        Content: Step 1a
+      </div>
+
+      <div class="btn-group">
+        <button type="button" class="btn btn-secondary" awNextStep>Continue</button>
+      </div>
+    </div>
+  </aw-wizard-step>
+
+  <aw-wizard-step [stepTitle]="'Steptitle 1b'">
+    <div class="centered-content">
+      <div>
+        Content: Step 1b
+      </div>
+
+      <div class="btn-group">
+        <button type="button" class="btn btn-secondary" awPreviousStep>Back</button>
+        <button type="button" class="btn btn-secondary" (click)="outerNext($event)">Continue</button>
+      </div>
+    </div>
+  </aw-wizard-step>
+</aw-wizard>

--- a/src/app/nested-wizards/inner-wizard.component.spec.ts
+++ b/src/app/nested-wizards/inner-wizard.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InnerWizardComponent } from './inner-wizard.component';
+import { NestedWizardsModule } from './nested-wizards.module';
+
+describe('InnerWizardComponent', () => {
+  let component: InnerWizardComponent;
+  let fixture: ComponentFixture<InnerWizardComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [NestedWizardsModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(InnerWizardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/nested-wizards/inner-wizard.component.ts
+++ b/src/app/nested-wizards/inner-wizard.component.ts
@@ -1,0 +1,29 @@
+import { Component, Input, OnInit, ViewChild } from '@angular/core';
+import { WizardComponent } from 'angular-archwizard';
+
+@Component({
+  selector: 'app-inner-wizard',
+  templateUrl: './inner-wizard.component.html',
+  styleUrls: ['./inner-wizard.component.css']
+})
+export class InnerWizardComponent implements OnInit {
+
+  @Input()
+  public outerWizard: WizardComponent;
+
+  @ViewChild('innerWizard')
+  public innerWizard: WizardComponent;
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+  outerNext(event): void {
+    this.outerWizard.goToNextStep();
+  }
+
+  reset(): void {
+    this.innerWizard.reset();
+  }
+}

--- a/src/app/nested-wizards/nested-wizards.component.css
+++ b/src/app/nested-wizards/nested-wizards.component.css
@@ -1,0 +1,4 @@
+.centered-content {
+  margin: auto;
+  text-align: center;
+}

--- a/src/app/nested-wizards/nested-wizards.component.html
+++ b/src/app/nested-wizards/nested-wizards.component.html
@@ -1,0 +1,18 @@
+<aw-wizard #outerWizard>
+  <aw-wizard-step [stepTitle]="'Steptitle 1'">
+    <app-inner-wizard #innerWizard [outerWizard]="outerWizard"></app-inner-wizard>
+  </aw-wizard-step>
+
+  <aw-wizard-step [stepTitle]="'Steptitle 2'">
+    <div class="centered-content">
+      <div>
+        Content: Step 2
+      </div>
+
+      <div class="btn-group">
+        <button type="button" class="btn btn-secondary" awPreviousStep>Back</button>
+        <button type="button" class="btn btn-secondary" awResetWizard (finalize)="innerWizard.reset()">Reset</button>
+      </div>
+    </div>
+  </aw-wizard-step>
+</aw-wizard>

--- a/src/app/nested-wizards/nested-wizards.component.spec.ts
+++ b/src/app/nested-wizards/nested-wizards.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NestedWizardsComponent } from './nested-wizards.component';
+import { NestedWizardsModule } from './nested-wizards.module';
+
+describe('NestedWizardsComponent', () => {
+  let component: NestedWizardsComponent;
+  let fixture: ComponentFixture<NestedWizardsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [NestedWizardsModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NestedWizardsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/nested-wizards/nested-wizards.component.ts
+++ b/src/app/nested-wizards/nested-wizards.component.ts
@@ -1,0 +1,13 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-nested-wizards',
+  templateUrl: './nested-wizards.component.html',
+  styleUrls: ['./nested-wizards.component.css']
+})
+export class NestedWizardsComponent implements OnInit {
+  constructor() { }
+
+  ngOnInit() {
+  }
+}

--- a/src/app/nested-wizards/nested-wizards.module.ts
+++ b/src/app/nested-wizards/nested-wizards.module.ts
@@ -1,0 +1,15 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ArchwizardModule } from 'angular-archwizard';
+import { NestedWizardsComponent } from './nested-wizards.component';
+import { InnerWizardComponent } from './inner-wizard.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ArchwizardModule
+  ],
+  declarations: [NestedWizardsComponent, InnerWizardComponent],
+  exports: [NestedWizardsComponent]
+})
+export class NestedWizardsModule { }


### PR DESCRIPTION
This PR adds an example showing two or more wizards can be nested

<a href="https://gitpod.io/#https://github.com/madoar/angular-archwizard-demo/pull/75"><img src="https://gitpod.io/api/apps/github/pbs/github.com/madoar/angular-archwizard-demo.git/ecd0bb02470bc12436cdc9a6737f2718e4bc9269.svg" /></a>

